### PR TITLE
fix: implement auth middleware to resolve signin redirection issue af…

### DIFF
--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,18 +1,31 @@
+// app/protected/page.tsx
+
 import { createClient } from "@/utils/supabase/server";
+import { error } from "console";
 import { InfoIcon } from "lucide-react";
 import { redirect } from "next/navigation";
 
 export default async function ProtectedPage() {
   const supabase = await createClient();
 
+  // Get the current user
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  console.log({data: {user}})
 
+  if (error) {
+    console.error("Error fetching user:", error);
+  }
+  
   if (!user) {
     return redirect("/sign-in");
   }
 
+  // If user is authenticated, redirect to dashboard
+  return redirect('/dashboard');
+
+  // // The code below will never run because of the redirect above
   return (
     <div className="flex-1 w-full flex flex-col gap-12">
       <div className="w-full">

--- a/components/header-auth.tsx
+++ b/components/header-auth.tsx
@@ -1,3 +1,5 @@
+// components/header.auth.tsx
+
 import { signOutAction } from "@/app/actions";
 import { hasEnvVars } from "@/utils/supabase/check-env-vars";
 import Link from "next/link";

--- a/lib/auth/signin.ts
+++ b/lib/auth/signin.ts
@@ -38,7 +38,7 @@ export const signInAction = async (formData: FormData) => {
     if (!requires2FA) {
       console.log("2FA not required, recording trusted device...");
       await recordTrustedDevice(data.user);
-      console.log("Redirecting to /protected...");
+      console.log("Redirecting to /dashboard ...");
       redirect("/dashboard");
     }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,59 @@
-// app/middleware.ts
-
-import { type NextRequest } from "next/server";
-import { updateSession } from "@/utils/supabase/middleware";
+// middleware.ts
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request);
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name) {
+          return request.cookies.get(name)?.value;
+        },
+        set(name, value, options) {
+          response.cookies.set({
+            name,
+            value,
+            ...options,
+          });
+        },
+        remove(name, options) {
+          response.cookies.set({
+            name,
+            value: '',
+            ...options,
+            maxAge: 0,
+          });
+        },
+      },
+    }
+  );
+
+  // Check auth state
+  const { data: { session } } = await supabase.auth.getSession();
+  const path = request.nextUrl.pathname;
+
+  // Redirect logic based on auth state
+  if (session && (path === '/sign-in' || path === '/sign-up' || path === '/')) {
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+
+  if (!session && (path.startsWith('/dashboard') || path === '/protected')) {
+    return NextResponse.redirect(new URL('/sign-in', request.url));
+  }
+
+  return response;
 }
 
+// Add the paths you want the middleware to run on
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths except:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - /sign-in (public route)
-     * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
-     */
-    "/((?!_next/static|_next/image|favicon.ico|sign-in|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
-  ],
+  matcher: ['/', '/dashboard/:path*', '/protected', '/sign-in', '/sign-up'],
 };


### PR DESCRIPTION
…ter dev server restart

Added middleware.ts to consistently check authentication state across the application. This ensures users with valid session cookies are properly recognized and redirected to /dashboard instead of /sign-in after restarting the development server with 'npm run dev'.

The middleware now intercepts requests to protected routes before page components load, correctly evaluates the session state from cookies, and handles redirects appropriately for both authenticated and unauthenticated users.